### PR TITLE
Duck disables player collision with enemies. Added layer names. 

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -64,6 +64,13 @@ pause={
 ]
 }
 
+[layer_names]
+
+2d_physics/layer_1="World"
+2d_physics/layer_2="Player"
+2d_physics/layer_3="Obstacles"
+2d_physics/layer_4="Enemies"
+
 [physics]
 
 2d/default_gravity=1100.0

--- a/scenes/game/characters/raskeladden.tscn
+++ b/scenes/game/characters/raskeladden.tscn
@@ -120,6 +120,8 @@ animations = [{
 }]
 
 [node name="Raskeladden" type="CharacterBody2D"]
+collision_layer = 3
+collision_mask = 13
 floor_stop_on_slope = false
 floor_max_angle = 1.41895
 floor_snap_length = 20.0

--- a/scenes/game/obstacles/bird.tscn
+++ b/scenes/game/obstacles/bird.tscn
@@ -76,6 +76,8 @@ animation = &"warn"
 autoplay = "swoop"
 
 [node name="Area2D" type="Area2D" parent="."]
+collision_layer = 8
+collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("CircleShape2D_vdr44")

--- a/scripts/entities/player.gd
+++ b/scripts/entities/player.gd
@@ -31,11 +31,12 @@ var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 @onready var anim_sprite = $"Sprites/AnimatedSprite2D"
 @onready var orig_color = anim_sprite.modulate
 
-@onready var collision := $CollisionShape2D
+@onready var collision : CollisionShape2D = $CollisionShape2D
 @onready var original_hitbox_pos = collision.position
 @onready var ducking_hitbox_pos :Vector2 = original_hitbox_pos + Vector2(0, 5)
 @onready var normal_hitbox : Shape2D = load("res://scenes/game/characters/raskeladden_hitbox.tres")
 @onready var ducking_hitbox : Shape2D = load("res://scenes/game/characters/raskeladden_hitbox_ducking.tres")
+const COLLISION_LAYER_PLAYER := 2
 
 # Movement vars
 const base_accel : float = 250.0
@@ -235,8 +236,10 @@ func _on_duck_button_pressed():
 		is_ducking = true
 		collision.shape = ducking_hitbox
 		collision.position = ducking_hitbox_pos
+		set_collision_layer_value(COLLISION_LAYER_PLAYER, false)
 		anim_sprite.play("duck")
 		duck_timer.start()
+
 func _on_jump_timer_timeout() -> void:
 	velocity.y = 0
 	hang_timer.start()
@@ -248,6 +251,7 @@ func _on_duck_timer_timeout() -> void:
 	is_ducking = false
 	collision.shape = normal_hitbox
 	collision.position = original_hitbox_pos
+	set_collision_layer_value(COLLISION_LAYER_PLAYER, true)
 
 ## Create a Timer with a timeout callback
 func create_timer(time : float, callback : Callable) -> Timer:


### PR DESCRIPTION
Duck now temporarily takes the player out of the 'player' layer, layer 2, allowing enemy hitboxes to ignore collision if their mask is set to target 2. Bird hitbox targets layer 2 for its attack.